### PR TITLE
Fix mistake in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ python main.py
 2. After each of AUTO-GPT's actions, type "NEXT COMMAND" to authorise them to continue.
 3. To exit the program, type "exit" and press Enter.
 
-## 🗣️ Speech Mode 
+## 🗣️ Speech Mode
+Use this to use TTS for Auto-GPT
 ```
-python main.py speach-mode
+python main.py speak-mode
 ```
 
 ## 💀 Continuous Mode ⚠️


### PR DESCRIPTION
The docs say the command to add TTS is `speach-mode`, while it's `speak-mode`. Just a small mistake, but still caused some issues.