### PR TITLE
fix: UnboundLocalError: local variable 'assistant_thoughts_reasoning' referenced before assignment

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -52,6 +52,10 @@ def print_assistant_thoughts(assistant_reply):
         # Parse and print Assistant response
         assistant_reply_json = fix_and_parse_json(assistant_reply)
 
+        assistant_thoughts_reasoning = None
+        assistant_thoughts_plan = None
+        assistant_thoughts_speak = None
+        assistant_thoughts_criticism = None
         try:
             assistant_thoughts = assistant_reply_json.get("thoughts")
             if assistant_thoughts:
@@ -66,7 +70,7 @@ def print_assistant_thoughts(assistant_reply):
                 assistant_thoughts_plan = None
                 assistant_thoughts_criticism = None
                 assistant_thoughts_speak = None
-        except Exception as e:
+        except Exception:
             assistant_thoughts_text = "The AI's response was unreadable."
 
         print_to_console(
@@ -86,7 +90,7 @@ def print_assistant_thoughts(assistant_reply):
                 elif isinstance(assistant_thoughts_plan, dict):
                     assistant_thoughts_plan = str(assistant_thoughts_plan)
                     # Split the input_string using the newline character and dash
-                
+
                 lines = assistant_thoughts_plan.split('\n')
 
                 # Iterate through the lines and print each one with a bullet
@@ -110,6 +114,7 @@ def print_assistant_thoughts(assistant_reply):
     except Exception as e:
         call_stack = traceback.format_exc()
         print_to_console("Error: \n", Fore.RED, call_stack)
+
 
 def load_variables(config_file="config.yaml"):
     # Load variables from yaml file if it exists

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -49,68 +49,44 @@ def print_assistant_thoughts(assistant_reply):
     global ai_name
     global cfg
     try:
-        # Parse and print Assistant response
         assistant_reply_json = fix_and_parse_json(assistant_reply)
 
         assistant_thoughts_reasoning = None
         assistant_thoughts_plan = None
         assistant_thoughts_speak = None
         assistant_thoughts_criticism = None
-        try:
-            assistant_thoughts = assistant_reply_json.get("thoughts")
-            if assistant_thoughts:
-                assistant_thoughts_text = assistant_thoughts.get("text")
-                assistant_thoughts_reasoning = assistant_thoughts.get("reasoning")
-                assistant_thoughts_plan = assistant_thoughts.get("plan")
-                assistant_thoughts_criticism = assistant_thoughts.get("criticism")
-                assistant_thoughts_speak = assistant_thoughts.get("speak")
-            else:
-                assistant_thoughts_text = None
-                assistant_thoughts_reasoning = None
-                assistant_thoughts_plan = None
-                assistant_thoughts_criticism = None
-                assistant_thoughts_speak = None
-        except Exception:
-            assistant_thoughts_text = "The AI's response was unreadable."
+        assistant_thoughts = assistant_reply_json.get("thoughts", {})
+        assistant_thoughts_text = assistant_thoughts.get("text")
 
-        print_to_console(
-            f"{ai_name.upper()} THOUGHTS:",
-            Fore.YELLOW,
-            assistant_thoughts_text)
-        print_to_console(
-            "REASONING:",
-            Fore.YELLOW,
-            assistant_thoughts_reasoning)
+        if assistant_thoughts:
+            assistant_thoughts_reasoning = assistant_thoughts.get("reasoning")
+            assistant_thoughts_plan = assistant_thoughts.get("plan")
+            assistant_thoughts_criticism = assistant_thoughts.get("criticism")
+            assistant_thoughts_speak = assistant_thoughts.get("speak")
+
+        print_to_console(f"{ai_name.upper()} THOUGHTS:", Fore.YELLOW, assistant_thoughts_text)
+        print_to_console("REASONING:", Fore.YELLOW, assistant_thoughts_reasoning)
+
         if assistant_thoughts_plan:
             print_to_console("PLAN:", Fore.YELLOW, "")
-            if assistant_thoughts_plan:
-                # If it's a list, join it into a string
-                if isinstance(assistant_thoughts_plan, list):
-                    assistant_thoughts_plan = "\n".join(assistant_thoughts_plan)
-                elif isinstance(assistant_thoughts_plan, dict):
-                    assistant_thoughts_plan = str(assistant_thoughts_plan)
-                    # Split the input_string using the newline character and dash
+            if isinstance(assistant_thoughts_plan, list):
+                assistant_thoughts_plan = "\n".join(assistant_thoughts_plan)
+            elif isinstance(assistant_thoughts_plan, dict):
+                assistant_thoughts_plan = str(assistant_thoughts_plan)
 
-                lines = assistant_thoughts_plan.split('\n')
+            lines = assistant_thoughts_plan.split('\n')
+            for line in lines:
+                line = line.lstrip("- ")
+                print_to_console("- ", Fore.GREEN, line.strip())
 
-                # Iterate through the lines and print each one with a bullet
-                # point
-                for line in lines:
-                    # Remove any "-" characters from the start of the line
-                    line = line.lstrip("- ")
-                    print_to_console("- ", Fore.GREEN, line.strip())
-        print_to_console(
-            "CRITICISM:",
-            Fore.YELLOW,
-            assistant_thoughts_criticism)
+        print_to_console("CRITICISM:", Fore.YELLOW, assistant_thoughts_criticism)
 
-        # Speak the assistant's thoughts
         if cfg.speak_mode and assistant_thoughts_speak:
             speak.say_text(assistant_thoughts_speak)
 
     except json.decoder.JSONDecodeError:
         print_to_console("Error: Invalid JSON\n", Fore.RED, assistant_reply)
-    # All other errors, return "Error: + error message"
+
     except Exception as e:
         call_stack = traceback.format_exc()
         print_to_console("Error: \n", Fore.RED, call_stack)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -49,6 +49,7 @@ def print_assistant_thoughts(assistant_reply):
     global ai_name
     global cfg
     try:
+        # Parse and print Assistant response
         assistant_reply_json = fix_and_parse_json(assistant_reply)
 
         assistant_thoughts_reasoning = None
@@ -69,24 +70,27 @@ def print_assistant_thoughts(assistant_reply):
 
         if assistant_thoughts_plan:
             print_to_console("PLAN:", Fore.YELLOW, "")
+            # If it's a list, join it into a string
             if isinstance(assistant_thoughts_plan, list):
                 assistant_thoughts_plan = "\n".join(assistant_thoughts_plan)
             elif isinstance(assistant_thoughts_plan, dict):
                 assistant_thoughts_plan = str(assistant_thoughts_plan)
 
+            # Split the input_string using the newline character and dashes
             lines = assistant_thoughts_plan.split('\n')
             for line in lines:
                 line = line.lstrip("- ")
                 print_to_console("- ", Fore.GREEN, line.strip())
 
         print_to_console("CRITICISM:", Fore.YELLOW, assistant_thoughts_criticism)
-
+        # Speak the assistant's thoughts
         if cfg.speak_mode and assistant_thoughts_speak:
             speak.say_text(assistant_thoughts_speak)
 
     except json.decoder.JSONDecodeError:
         print_to_console("Error: Invalid JSON\n", Fore.RED, assistant_reply)
 
+    # All other errors, return "Error: + error message"
     except Exception as e:
         call_stack = traceback.format_exc()
         print_to_console("Error: \n", Fore.RED, call_stack)


### PR DESCRIPTION
This PR fixes an issue in the `print_assistant_thoughts` function that caused a `UnboundLocalError` when `assistant_thoughts_reasoning` was referenced before assignment. 

To solve this, I have initialized all variables to `None` before trying to retrieve them from `assistant_reply_json`. This ensures that all variables are defined even if they are not included in the JSON response.



