### PR TITLE
Patch readme "copy" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ git clone https://github.com/Torantulino/Auto-GPT.git
 2. Navigate to the project directory:
 *(Type this into your CMD window, you're aiming to navigate the CMD window to the repository you just downloaded)*
 ```
-$ cd 'Auto-GPT'
+cd 'Auto-GPT'
 ```
 
 3. Install the required dependencies:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28759336/229825160-8d04ccce-0c56-405c-a00a-07c393aad3cf.png)

"$" was annoying when copy/pasting the command. And that was the only line with the character.