### PR TITLE
Fixed speech blocking main thread

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 colorama==0.4.6
 openai==0.27.2
-playsound==1.3.0
+playsound==1.2.2
 python-dotenv==1.0.0
 pyyaml==6.0
 readability-lxml==0.8.1

--- a/scripts/speak.py
+++ b/scripts/speak.py
@@ -4,6 +4,8 @@ import requests
 from config import Config
 cfg = Config()
 import gtts
+import threading
+from threading import Lock
 
 
 # TODO: Nicer names for these ids
@@ -14,18 +16,21 @@ tts_headers = {
     "xi-api-key": cfg.elevenlabs_api_key
 }
 
+mutex_lock = Lock() # Ensure only one sound is played at a time
+
 def eleven_labs_speech(text, voice_index=0):
     tts_url = "https://api.elevenlabs.io/v1/text-to-speech/{voice_id}".format(
         voice_id=voices[voice_index])
-    formatted_message = {"text": text}
+    formatted_message = {"text": text, "voice_settings": {"stability": 0.05, "similarity_boost": 0.8}}
     response = requests.post(
         tts_url, headers=tts_headers, json=formatted_message)
 
     if response.status_code == 200:
-        with open("speech.mpeg", "wb") as f:
-            f.write(response.content)
-        playsound("speech.mpeg")
-        os.remove("speech.mpeg")
+        with mutex_lock:
+            with open("speech.mpeg", "wb") as f:
+                f.write(response.content)
+            playsound("speech.mpeg", True)
+            os.remove("speech.mpeg")
         return True
     else:
         print("Request failed with status code:", response.status_code)
@@ -34,15 +39,19 @@ def eleven_labs_speech(text, voice_index=0):
 
 def gtts_speech(text):
     tts = gtts.gTTS(text)
-    tts.save("speech.mp3")
-    playsound("speech.mp3")
-    os.remove("speech.mp3")
+    with mutex_lock:
+        tts.save("speech.mp3")
+        playsound("speech.mp3", True)
+        os.remove("speech.mp3")
 
 def say_text(text, voice_index=0):
-    if not cfg.elevenlabs_api_key:
-        gtts_speech(text)
-    else:
-        success = eleven_labs_speech(text)
-        if not success:
+    def speak():
+        if not cfg.elevenlabs_api_key:
             gtts_speech(text)
+        else:
+            success = eleven_labs_speech(text)
+            if not success:
+                gtts_speech(text)
 
+    thread = threading.Thread(target=speak)
+    thread.start()


### PR DESCRIPTION
Previously, playing the speech sound would block the main thread. Resulting in any computation halting until the sound had finishes playing. This is inefficient, as the program could be doing useful work while the sound plays.

This pull request adds a thread-safe implementation of "queueing" the speech, allowing for a more efficient use of time.