### PR TITLE
fix(json-jixer): enclose arguments in a python multi-line string so t…

### DIFF
--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -51,7 +51,7 @@ def fix_and_parse_json(json_str: str, try_to_fix_with_gpt: bool = True):
 def fix_json(json_str: str, schema: str, debug=False) -> str:
     # Try to fix the JSON using gpt:
     function_string = "def fix_json(json_str: str, schema:str=None) -> str:"
-    args = [json_str, schema]
+    args = [f"'''{json_str}'''", f"'''{schema}'''"]
     description_string = """Fixes the provided JSON string to make it parseable and fully complient with the provided schema.\n If an object or field specifed in the schema isn't contained within the correct JSON, it is ommited.\n This function is brilliant at guessing when the format is incorrect."""
 
     # If it doesn't already start with a "`", add one:


### PR DESCRIPTION
Assistant is often providing invalid JSON (assistant_reply in main), such as:
{
    "command": {
        "name": "google",
        "args": {
            "input": "blabla",
        }
    },
    "thoughts": {
        "text": "Search results indicate that ..."
    }
}

As you see, there shouldn't be a comma after "input" in "args".

When trying to fix the JSON, the JSON fixer assistant is provided with the prompt:
```
You are now the following python function: ```# Fixes the provided JSON string to make it parseable and fully complient with the provided schema.
 If an object or field specifed in the schema isn't contained within the correct JSON, it is ommited.
 This function is brilliant at guessing when the format is incorrect.
def fix_json(json_str: str, schema:str=None) -> str:```

Only respond with your `return` value.
```

Then the next message, the json and it's schema are provided in this form:

```
{
    "command": {
        "name": "google",
        "args": {
            "input": "blabla",
        }
    },
    "thoughts": {
        "text": "Search results indicate that ..."
    }
},
    {
     ... the schema...
    }
```

gpt-3.5 is used for this request, but is thinking that this is the first argument of the function, and is replying:
'This is not a valid return value for the `fix_json` function. The provided code is a JSON object containing two separate JSON objects. Please provide a valid return value for the `fix_json` function.'

enclosing each string arguments with a python multi-line string will solve the problem.