### PR TITLE
fixing the "TypeError('the JSON object must be str, bytes or bytearray, not dict')" after a json_fix is successful

### DIFF
--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -67,7 +67,8 @@ def fix_json(json_str: str, schema: str, debug=False) -> str:
         print(f"Fixed JSON: {result_string}")
         print("----------- END OF FIX ATTEMPT ----------------")
     try:
-        return json.loads(result_string)
+        json.loads(result_string) # just check the validity
+        return result_string
     except:
         # Get the call stack:
         # import traceback


### PR DESCRIPTION
The fix_json error is expected to return str.
In case of success, the function does a json.loads() and returns a JSON, which cause a "TypeError('the JSON object must be str, bytes or bytearray, not dict')" in the caller