### PR TITLE
first draft of github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -1,0 +1,39 @@
+name: Bug report 🐛
+description: Create a bug report for Auto-GPT.
+labels: ['status: needs triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        Thanks for contributing by creating an issue! ❤️
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/Torantulino/Auto-GPT/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce 🕹
+      description: |
+        **⚠️ Issues that we can't reproduce will be closed.**
+  - type: textarea
+    attributes:
+      label: Current behavior 😯
+      description: Describe what happens instead of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Expected behavior 🤔
+      description: Describe what should happen.
+  - type: textarea
+    attributes:
+      label: Your prompt 📝
+      description: |
+        Please provide the prompt you are using. You can find your last-used prompt in last_run_ai_settings.yaml.
+      value: |
+        ```yaml
+        # Paste your prompt here
+        ```

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -1,0 +1,29 @@
+name: Feature request 🚀
+description: Suggest a new idea for Auto-GPT.
+labels: ['status: needs triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a searchable summary of the issue in the title above ⬆️.
+
+        Thanks for contributing by creating an issue! ❤️
+  - type: checkboxes
+    attributes:
+      label: Duplicates
+      description: Please [search the history](https://github.com/Torantulino/Auto-GPT/issues) to see if an issue already exists for the same problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Summary 💡
+      description: Describe how it should work.
+  - type: textarea
+    attributes:
+      label: Examples 🌈
+      description: Provide a link to other implementations, or screenshots of the expected behavior.
+  - type: textarea
+    attributes:
+      label: Motivation 🔦
+      description: What are you trying to accomplish? How has the lack of this feature affected you? Providing context helps us come up with a solution that is more useful in the real world.


### PR DESCRIPTION
I added issue templates to help organize the incoming issues. With these templates when someone creates a new issue they get to choose from these options:

![image](https://user-images.githubusercontent.com/1555339/230211317-c22fb452-f0ba-4a38-bf37-cb1c19c30203.png)

----------
The bug report template looks like this:
<img width="753" alt="image" src="https://user-images.githubusercontent.com/1555339/230211500-11aee6b9-83a8-40f4-a23f-18f130b553eb.png">



--------------

The feature request template looks like this:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/1555339/230211831-63d0d725-c20c-4394-adc5-ac7c28e000b0.png">


