### PR TITLE
Added fake user-agent headers to browser request.

### DIFF
--- a/scripts/browse.py
+++ b/scripts/browse.py
@@ -6,7 +6,7 @@ from llm_utils import create_chat_completion
 cfg = Config()
 
 def scrape_text(url):
-    response = requests.get(url)
+    response = requests.get(url, headers=cfg.user_agent_header)
 
     # Check if the response contains an HTTP error
     if response.status_code >= 400:
@@ -40,7 +40,7 @@ def format_hyperlinks(hyperlinks):
 
 
 def scrape_links(url):
-    response = requests.get(url)
+    response = requests.get(url, headers=cfg.user_agent_header)
 
     # Check if the response contains an HTTP error
     if response.status_code >= 400:

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -39,6 +39,11 @@ class Config(metaclass=Singleton):
         self.google_api_key = os.getenv("GOOGLE_API_KEY")
         self.custom_search_engine_id = os.getenv("CUSTOM_SEARCH_ENGINE_ID")
 
+        # User agent headers to use when browsing web
+        # Some websites might just completely deny request with an error code if no user agent was found.
+        self.user_agent_header = {"User-Agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"}
+
+
         # Initialize the OpenAI API client
         openai.api_key = self.openai_api_key
 


### PR DESCRIPTION
Greetings,
I discovered that some sites are inaccessible due to the lack of user-agent headers. For instance, I tried to access 'https://etherscan.io/accounts' using the requests.get() method, but it returned a 403 error. Therefore, I added some fake user-agent headers to the request, which seemed to fix the issue.

To avoid adding more libraries to the project, I hard-coded the headers. However, I could implement a better solution by using the 'fake-useragent' library (or a similar one) if you prefer. That being said I believe the current solution is fine at least for now.
