### PR TITLE
Changed order of pinecone explaination too avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ are loaded for the agent at any given time.
 
 Simply set them in the `.env` file. 
 
-Alternatively you can use the appropriate following method (advanced):
+Alternatively, you can set them from the command line (advanced):
 
 For Windows Users:
 ```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,12 @@ are loaded for the agent at any given time.
 3. Find your API key and region under the default project in the left sidebar.
 
 ### Setting up environment variables
-   For Windows Users:
+
+Simply set them in the `.env` file. 
+
+Alternatively you can use the appropriate following method (advanced):
+
+For Windows Users:
 ```
 setx PINECONE_API_KEY "YOUR_PINECONE_API_KEY"
 export PINECONE_ENV="Your pinecone region" # something like: us-east4-gcp
@@ -163,7 +168,6 @@ export PINECONE_ENV="Your pinecone region" # something like: us-east4-gcp
 
 ```
 
-Or you can set them in the `.env` file.
 
 ## View Memory Usage
 


### PR DESCRIPTION
Just adding the keys to .env is easier for most users. The current way confuses alot of people which causes lots of repetitive questions on github aswell as on discord.