### PR TITLE
🛠️ 🧰 Fix call_ai_function storing gpt-4 into kwarg model even when using gpt3only

### DIFF
--- a/scripts/call_ai_function.py
+++ b/scripts/call_ai_function.py
@@ -5,7 +5,9 @@ from llm_utils import create_chat_completion
 
 # This is a magic function that can do anything with no-code. See
 # https://github.com/Torantulino/AI-Functions for more info.
-def call_ai_function(function, args, description, model=cfg.smart_llm_model):
+def call_ai_function(function, args, description, model=None):
+    if model is None:
+        model = cfg.smart_llm_model
     # For each arg, if any are None, convert to "None":
     args = [str(arg) if arg is not None else "None" for arg in args]
     # parse args to comma seperated string


### PR DESCRIPTION
The function kwarg `model` default was storing gpt-4 value at import time, leading to yield a value of gpt-4. Even after setting gpt3only, because that happens later. By that time `gpt-4` is already stored in as the default value.

This PR fixes that for us folks still waiting to unlock gpt-4 usage.