### PR TITLE
Pinecone improvements: Namespaces and Persistent Memory

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 PINECONE_API_KEY=your-pinecone-api-key
 PINECONE_ENV=your-pinecone-region
+PINECONE_NAMESPACE=your-pinecone-namespace (leave blank for default)
 OPENAI_API_KEY=your-openai-api-key
 ELEVENLABS_API_KEY=your-elevenlabs-api-key
 SMART_LLM_MODEL="gpt-4"

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,6 @@
 PINECONE_API_KEY=your-pinecone-api-key
 PINECONE_ENV=your-pinecone-region
-PINECONE_NAMESPACE=your-pinecone-namespace (leave blank for default)
+PINECONE_NAMESPACE_OVERRIDE=your-pinecone-namespace-if-you-want-it-to-be-different-from-autogpt-name
 OPENAI_API_KEY=your-openai-api-key
 ELEVENLABS_API_KEY=your-elevenlabs-api-key
 SMART_LLM_MODEL="gpt-4"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ auto_gpt_workspace/*
 .env
 outputs/*
 ai_settings.yaml
+.vscode/*

--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -44,6 +44,7 @@ def chat_with_ai(
         full_message_history,
         permanent_memory,
         token_limit,
+        ns,
         debug=False):
     while True:
         try:
@@ -66,7 +67,7 @@ def chat_with_ai(
                 print(f"Token limit: {token_limit}")
             send_token_limit = token_limit - 1000
 
-            relevant_memory = permanent_memory.get_relevant(str(full_message_history[-5:]), 10)
+            relevant_memory = permanent_memory.get_relevant(str(full_message_history[-5:]), ns, 10)
 
             if debug:
                 print('Memory Stats: ', permanent_memory.get_stats())

--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -63,7 +63,7 @@ def execute_command(command_name, arguments):
             else:
                 return google_search(arguments["input"])
         elif command_name == "memory_add":
-            return memory.add(arguments["string"])
+            return memory.add(arguments["string"], cfg.pinecone_namespace)
         elif command_name == "start_agent":
             return start_agent(
                 arguments["name"],

--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -63,7 +63,7 @@ def execute_command(command_name, arguments):
             else:
                 return google_search(arguments["input"])
         elif command_name == "memory_add":
-            return memory.add(arguments["string"], cfg.pinecone_namespace)
+            return memory.add(arguments["string"])
         elif command_name == "start_agent":
             return start_agent(
                 arguments["name"],

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -52,7 +52,7 @@ class Config(metaclass=Singleton):
 
         self.pinecone_api_key = os.getenv("PINECONE_API_KEY")
         self.pinecone_region = os.getenv("PINECONE_ENV")
-        self.pinecone_namespace = os.getenv("PINECONE_NAMESPACE")
+        self.pinecone_namespace_override = os.getenv("PINECONE_NAMESPACE_OVERRIDE")
         self.pinecone_clear_long_term_memory_requested = False
 
         # User agent headers to use when browsing web
@@ -98,8 +98,8 @@ class Config(metaclass=Singleton):
     def set_pinecone_region(self, value: str):
         self.pinecone_region = value
 
-    def set_pinecone_namespace(self, value: str):
-        self.pinecone_namespace = value
+    def set_pinecone_namespace_override(self, value: str):
+        self.pinecone_namespace_override = value
 
     def set_pinecone_clear_long_term_memory_requested(self, value: str):
         self.pinecone_clear_long_term_memory_requested = value

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -52,6 +52,8 @@ class Config(metaclass=Singleton):
 
         self.pinecone_api_key = os.getenv("PINECONE_API_KEY")
         self.pinecone_region = os.getenv("PINECONE_ENV")
+        self.pinecone_namespace = os.getenv("PINECONE_NAMESPACE")
+        self.pinecone_clear_long_term_memory_requested = False
 
         # User agent headers to use when browsing web
         # Some websites might just completely deny request with an error code if no user agent was found.
@@ -95,3 +97,9 @@ class Config(metaclass=Singleton):
 
     def set_pinecone_region(self, value: str):
         self.pinecone_region = value
+
+    def set_pinecone_namespace(self, value: str):
+        self.pinecone_namespace = value
+
+    def set_pinecone_clear_long_term_memory_requested(self, value: str):
+        self.pinecone_clear_long_term_memory_requested = value

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -248,6 +248,7 @@ def parse_arguments():
     parser.add_argument('--speak', action='store_true', help='Enable Speak Mode')
     parser.add_argument('--debug', action='store_true', help='Enable Debug Mode')
     parser.add_argument('--gpt3only', action='store_true', help='Enable GPT3.5 Only Mode')
+    parser.add_argument('--clearLongTermMemory', action='store_true', help='Clear long term memory for this agent\'s context on startup')
     args = parser.parse_args()
 
     if args.continuous:
@@ -266,6 +267,8 @@ def parse_arguments():
         print_to_console("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")
         cfg.set_smart_llm_model(cfg.fast_llm_model)
 
+    if args.clearLongTermMemory:
+        cfg.set_pinecone_clear_long_term_memory_requested(True)
 
 # TODO: fill in llm values here
 
@@ -284,9 +287,11 @@ user_input = "Determine which next command to use, and respond using the format 
 # Initialize memory and make sure it is empty.
 # this is particularly important for indexing and referencing pinecone memory
 memory = PineconeMemory()
-memory.clear()
-
 print('Using memory of type: ' + memory.__class__.__name__)
+
+if cfg.pinecone_clear_long_term_memory_requested:
+  memory.clear(cfg.pinecone_namespace)
+
 
 # Interaction Loop
 while True:
@@ -297,7 +302,8 @@ while True:
             user_input,
             full_message_history,
             memory,
-            cfg.fast_token_limit) # TODO: This hardcodes the model to use GPT3.5. Make this an argument
+            cfg.fast_token_limit, # TODO: This hardcodes the model to use GPT3.5. Make this an argument
+            cfg.pinecone_namespace) 
 
     # Print Assistant thoughts
     print_assistant_thoughts(assistant_reply)
@@ -370,7 +376,7 @@ while True:
                     f"\nResult: {result} " \
                     f"\nHuman Feedback: {user_input} "
 
-    memory.add(memory_to_add)
+    memory.add(memory_to_add, cfg.pinecone_namespace)
 
     # Check if there's a result from the command append it to the message
     # history

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -284,13 +284,20 @@ next_action_count = 0
 # Make a constant:
 user_input = "Determine which next command to use, and respond using the format specified above:"
 
-# Initialize memory and make sure it is empty.
-# this is particularly important for indexing and referencing pinecone memory
-memory = PineconeMemory()
+#
+# Memory Initialisation
+#
+
+pinecone_namespace = ai_name
+if cfg.pinecone_namespace_override:
+    pinecone_namespace = cfg.pinecone_namespace_override
+memory = PineconeMemory(pinecone_namespace)
+
 print('Using memory of type: ' + memory.__class__.__name__)
 
+# clear the memory for this namespace if requested
 if cfg.pinecone_clear_long_term_memory_requested:
-  memory.clear(cfg.pinecone_namespace)
+  memory.clear()
 
 
 # Interaction Loop
@@ -303,7 +310,7 @@ while True:
             full_message_history,
             memory,
             cfg.fast_token_limit, # TODO: This hardcodes the model to use GPT3.5. Make this an argument
-            cfg.pinecone_namespace) 
+            pinecone_namespace) 
 
     # Print Assistant thoughts
     print_assistant_thoughts(assistant_reply)
@@ -376,7 +383,7 @@ while True:
                     f"\nResult: {result} " \
                     f"\nHuman Feedback: {user_input} "
 
-    memory.add(memory_to_add, cfg.pinecone_namespace)
+    memory.add(memory_to_add, pinecone_namespace)
 
     # Check if there's a result from the command append it to the message
     # history

--- a/scripts/memory.py
+++ b/scripts/memory.py
@@ -23,37 +23,38 @@ class PineconeMemory(metaclass=Singleton):
         metric = "cosine"
         pod_type = "p1"
         table_name = "auto-gpt"
-        # this assumes we don't start with memory.
-        # for now this works.
-        # we'll need a more complicated and robust system if we want to start with memory.
-        self.vec_num = 0
+
         if table_name not in pinecone.list_indexes():
             pinecone.create_index(table_name, dimension=dimension, metric=metric, pod_type=pod_type)
         self.index = pinecone.Index(table_name)
 
-    def add(self, data):
+        # figure out what vector number to start with by pulling the total vector count
+        index_stats = self.index.describe_index_stats()
+        self.vec_num = index_stats._data_store.get('total_vector_count')
+
+    def add(self, data, ns):
         vector = get_ada_embedding(data)
         # no metadata here. We may wish to change that long term.
-        resp = self.index.upsert([(str(self.vec_num), vector, {"raw_text": data})])
+        resp = self.index.upsert([(str(self.vec_num), vector, {"raw_text": data})], namespace=ns)
         _text = f"Inserting data into memory at index: {self.vec_num}:\n data: {data}"
         self.vec_num += 1
         return _text
 
-    def get(self, data):
-        return self.get_relevant(data, 1)
+    def get(self, data, ns):
+        return self.get_relevant(data, ns, 1)
 
-    def clear(self):
-        self.index.delete(deleteAll=True)
+    def clear(self, ns):
+        self.index.delete(delete_all=True, namespace=ns)
         return "Obliviated"
 
-    def get_relevant(self, data, num_relevant=5):
+    def get_relevant(self, data, ns, num_relevant=5):
         """
         Returns all the data in the memory that is relevant to the given data.
         :param data: The data to compare to.
         :param num_relevant: The number of relevant data to return. Defaults to 5
         """
         query_embedding = get_ada_embedding(data)
-        results = self.index.query(query_embedding, top_k=num_relevant, include_metadata=True)
+        results = self.index.query(query_embedding, top_k=num_relevant, include_metadata=True, namespace=ns)
         sorted_results = sorted(results.matches, key=lambda x: x.score)
         return [str(item['metadata']["raw_text"]) for item in sorted_results]
 


### PR DESCRIPTION
Namespaces allow multiple Auto-GPT agents to use the same subscription to Pinecone. Additionally (and maybe more importantly) it sets the groundwork for future work to make spinoff agents work in their own (temporary) namespaces. Set the PINECONE_NAMESPACE in your .env file, or leave it blank to use the default.

Persistent memory lets memory entries in Pinecone persist between Auto-GPT sessions. By default this is turned on. If you want to clear the long term memory for your namespace before you begin your next session, use the new --clearLongTermMemory flag on the command line.