### PR TITLE
Add an exponential backoff to openai.error.RateLimitError:

### DIFF
--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -45,99 +45,109 @@ def chat_with_ai(
         permanent_memory,
         token_limit,
         debug=False):
+        
+    max_retries = 7
+    backoff_factor = 2
     while True:
-        try:
-            """
-            Interact with the OpenAI API, sending the prompt, user input, message history, and permanent memory.
+        retry = 0
+        while retry < max_retries:
+            try:
+                """
+                Interact with the OpenAI API, sending the prompt, user input, message history, and permanent memory.
+    
+                Args:
+                prompt (str): The prompt explaining the rules to the AI.
+                user_input (str): The input from the user.
+                full_message_history (list): The list of all messages sent between the user and the AI.
+                permanent_memory (Obj): The memory object containing the permanent memory.
+                token_limit (int): The maximum number of tokens allowed in the API call.
+    
+                Returns:
+                str: The AI's response.
+                """
+                model = cfg.fast_llm_model # TODO: Change model from hardcode to argument
+                # Reserve 1000 tokens for the response
+                if debug:
+                    print(f"Token limit: {token_limit}")
+                send_token_limit = token_limit - 1000
 
-            Args:
-            prompt (str): The prompt explaining the rules to the AI.
-            user_input (str): The input from the user.
-            full_message_history (list): The list of all messages sent between the user and the AI.
-            permanent_memory (Obj): The memory object containing the permanent memory.
-            token_limit (int): The maximum number of tokens allowed in the API call.
+                relevant_memory = permanent_memory.get_relevant(str(full_message_history[-5:]), 10)
 
-            Returns:
-            str: The AI's response.
-            """
-            model = cfg.fast_llm_model # TODO: Change model from hardcode to argument
-            # Reserve 1000 tokens for the response
-            if debug:
-                print(f"Token limit: {token_limit}")
-            send_token_limit = token_limit - 1000
+                if debug:
+                    print('Memory Stats: ', permanent_memory.get_stats())
 
-            relevant_memory = permanent_memory.get_relevant(str(full_message_history[-5:]), 10)
-
-            if debug:
-                print('Memory Stats: ', permanent_memory.get_stats())
-
-            next_message_to_add_index, current_tokens_used, insertion_index, current_context = generate_context(
-                prompt, relevant_memory, full_message_history, model)
-
-            while current_tokens_used > 2500:
-                # remove memories until we are under 2500 tokens
-                relevant_memory = relevant_memory[1:]
                 next_message_to_add_index, current_tokens_used, insertion_index, current_context = generate_context(
                     prompt, relevant_memory, full_message_history, model)
 
-            current_tokens_used += token_counter.count_message_tokens([create_chat_message("user", user_input)], model) # Account for user input (appended later)
+                while current_tokens_used > 2500:
+                    # remove memories until we are under 2500 tokens
+                    relevant_memory = relevant_memory[1:]
+                    next_message_to_add_index, current_tokens_used, insertion_index, current_context = generate_context(
+                        prompt, relevant_memory, full_message_history, model)
 
-            while next_message_to_add_index >= 0:
-                # print (f"CURRENT TOKENS USED: {current_tokens_used}")
-                message_to_add = full_message_history[next_message_to_add_index]
+                current_tokens_used += token_counter.count_message_tokens([create_chat_message("user", user_input)], model) # Account for user input (appended later)
 
-                tokens_to_add = token_counter.count_message_tokens([message_to_add], model)
-                if current_tokens_used + tokens_to_add > send_token_limit:
-                    break
+                while next_message_to_add_index >= 0:
+                    # print (f"CURRENT TOKENS USED: {current_tokens_used}")
+                    message_to_add = full_message_history[next_message_to_add_index]
 
-                # Add the most recent message to the start of the current context, after the two system prompts.
-                current_context.insert(insertion_index, full_message_history[next_message_to_add_index])
+                    tokens_to_add = token_counter.count_message_tokens([message_to_add], model)
+                    if current_tokens_used + tokens_to_add > send_token_limit:
+                        break
 
-                # Count the currently used tokens
-                current_tokens_used += tokens_to_add
-                
-                # Move to the next most recent message in the full message history
-                next_message_to_add_index -= 1
+                    # Add the most recent message to the start of the current context, after the two system prompts.
+                    current_context.insert(insertion_index, full_message_history[next_message_to_add_index])
 
-            # Append user input, the length of this is accounted for above
-            current_context.extend([create_chat_message("user", user_input)])
+                    # Count the currently used tokens
+                    current_tokens_used += tokens_to_add
 
-            # Calculate remaining tokens
-            tokens_remaining = token_limit - current_tokens_used
-            # assert tokens_remaining >= 0, "Tokens remaining is negative. This should never happen, please submit a bug report at https://www.github.com/Torantulino/Auto-GPT"
+                    # Move to the next most recent message in the full message history
+                    next_message_to_add_index -= 1
 
-            # Debug print the current context
-            if debug:
-                print(f"Token limit: {token_limit}")
-                print(f"Send Token Count: {current_tokens_used}")
-                print(f"Tokens remaining for response: {tokens_remaining}")
-                print("------------ CONTEXT SENT TO AI ---------------")
-                for message in current_context:
-                    # Skip printing the prompt
-                    if message["role"] == "system" and message["content"] == prompt:
-                        continue
-                    print(
-                        f"{message['role'].capitalize()}: {message['content']}")
-                    print()
-                print("----------- END OF CONTEXT ----------------")
+                # Append user input, the length of this is accounted for above
+                current_context.extend([create_chat_message("user", user_input)])
 
-            # TODO: use a model defined elsewhere, so that model can contain temperature and other settings we care about
-            assistant_reply = create_chat_completion(
-                model=model,
-                messages=current_context,
-                max_tokens=tokens_remaining,
-            )
+                # Calculate remaining tokens
+                tokens_remaining = token_limit - current_tokens_used
+                # assert tokens_remaining >= 0, "Tokens remaining is negative. This should never happen, please submit a bug report at https://www.github.com/Torantulino/Auto-GPT"
 
-            # Update full message history
-            full_message_history.append(
-                create_chat_message(
-                    "user", user_input))
-            full_message_history.append(
-                create_chat_message(
-                    "assistant", assistant_reply))
+                # Debug print the current context
+                if debug:
+                    print(f"Token limit: {token_limit}")
+                    print(f"Send Token Count: {current_tokens_used}")
+                    print(f"Tokens remaining for response: {tokens_remaining}")
+                    print("------------ CONTEXT SENT TO AI ---------------")
+                    for message in current_context:
+                        # Skip printing the prompt
+                        if message["role"] == "system" and message["content"] == prompt:
+                            continue
+                        print(
+                            f"{message['role'].capitalize()}: {message['content']}")
+                        print()
+                    print("----------- END OF CONTEXT ----------------")
 
-            return assistant_reply
-        except openai.error.RateLimitError:
-            # TODO: WHen we switch to langchain, this is built in
-            print("Error: ", "API Rate Limit Reached. Waiting 10 seconds...")
-            time.sleep(10)
+                # TODO: use a model defined elsewhere, so that model can contain temperature and other settings we care about
+                assistant_reply = create_chat_completion(
+                    model=model,
+                    messages=current_context,
+                    max_tokens=tokens_remaining,
+                )
+
+                # Update full message history
+                full_message_history.append(
+                    create_chat_message(
+                        "user", user_input))
+                full_message_history.append(
+                    create_chat_message(
+                        "assistant", assistant_reply))
+
+                return assistant_reply
+            except openai.error.RateLimitError:
+                # TODO: WHen we switch to langchain, this is built in
+                sleep_time = backoff_factor ** retry
+                print(f"Error: OpenAI API Rate Limit Reached (attempt {retry}). Waiting {sleep_time} seconds...")
+                time.sleep(sleep_time)
+                retry += 1
+        else:
+            print("Error: Maximum retries reached. Exiting.")
+            break


### PR DESCRIPTION
## Description

If we catch an openai.error.RateLimitError then retry with an exponential back-off.

I was experiencing lots of 'Error:  API Rate Limit Reached. Waiting 10 seconds...' and figured that the API could do with some breathing room with OpenApi gradually adjusting for demand.

Large diff due to indentation, but all I have really changed is:

```
    max_retries = 7
    backoff_factor = 2
```

And

```
      except openai.error.RateLimitError:
          # TODO: WHen we switch to langchain, this is built in
          sleep_time = backoff_factor ** retry
          print(f"Error: API Rate Limit Reached. Waiting {sleep_time} seconds...")
          time.sleep(sleep_time)
          retry += 1
  else:
      print("Error: Maximum retries reached. Exiting.")
      break
```

## Testing / Reviewer Guidelines

I'm happy to mock out a test for this change. I suspect a new folder with tests for each /scripts/ file should be created.