### PR TITLE
🖼 Image Generation: Adds DALL-e and Stable Diffusion support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,3 +10,5 @@ USE_AZURE=False
 OPENAI_API_BASE=your-base-url-for-azure
 OPENAI_API_VERSION=api-version-for-azure
 OPENAI_DEPLOYMENT_ID=deployment-id-for-azure
+IMAGE_PROVIDER=dalle
+HUGGINGFACE_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Your support is greatly appreciated
     - [Setting up environment variables](#setting-up-environment-variables)
   - [💀 Continuous Mode ⚠️](#-continuous-mode-️)
   - [GPT3.5 ONLY Mode](#gpt35-only-mode)
+  - [🖼 Image Generation](#image-generation)
   - [⚠️ Limitations](#️-limitations)
   - [🛡 Disclaimer](#-disclaimer)
   - [🐦 Connect with Us on Twitter](#-connect-with-us-on-twitter)
@@ -169,6 +170,7 @@ Or you can set them in the `.env` file.
 
 1. View memory usage by using the `--debug` flag :)
 
+
 ## 💀 Continuous Mode ⚠️
 Run the AI **without** user authorisation, 100% automated.
 Continuous mode is not recommended. 
@@ -185,6 +187,15 @@ python scripts/main.py --continuous
 If you don't have access to the GPT4 api, this mode will allow you to use Auto-GPT!
 ```
 python scripts/main.py --gpt3only
+```
+
+## 🖼 Image Generation
+By default, Auto-GPT uses DALL-e for image generation. To use Stable Diffusion, a [HuggingFace API Token](https://huggingface.co/settings/tokens) is required.
+
+Once you have a token, set these variables in your `.env`:
+```
+IMAGE_PROVIDER=sd
+HUGGINGFACE_API_TOKEN="YOUR_HUGGINGFACE_API_TOKEN"
 ```
 
 ## ⚠️ Limitations

--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -9,6 +9,7 @@ import ai_functions as ai
 from file_operations import read_file, write_to_file, append_to_file, delete_file, search_files
 from execute_code import execute_python_file
 from json_parser import fix_and_parse_json
+from image_gen import generate_image
 from duckduckgo_search import ddg
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
@@ -102,6 +103,8 @@ def execute_command(command_name, arguments):
             return ai.write_tests(arguments["code"], arguments.get("focus"))
         elif command_name == "execute_python_file":  # Add this command
             return execute_python_file(arguments["file"])
+        elif command_name == "generate_image":  # Add this command
+            return generate_image(arguments["prompt"])
         elif command_name == "task_complete":
             shutdown()
         else:

--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -103,7 +103,7 @@ def execute_command(command_name, arguments):
             return ai.write_tests(arguments["code"], arguments.get("focus"))
         elif command_name == "execute_python_file":  # Add this command
             return execute_python_file(arguments["file"])
-        elif command_name == "generate_image":  # Add this command
+        elif command_name == "generate_image":
             return generate_image(arguments["prompt"])
         elif command_name == "task_complete":
             shutdown()

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -53,6 +53,8 @@ class Config(metaclass=Singleton):
         self.pinecone_api_key = os.getenv("PINECONE_API_KEY")
         self.pinecone_region = os.getenv("PINECONE_ENV")
 
+        self.huggingface_api_token = os.getenv("HUGGINGFACE_API_TOKEN")
+
         # User agent headers to use when browsing web
         # Some websites might just completely deny request with an error code if no user agent was found.
         self.user_agent_header = {"User-Agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"}

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -53,6 +53,7 @@ class Config(metaclass=Singleton):
         self.pinecone_api_key = os.getenv("PINECONE_API_KEY")
         self.pinecone_region = os.getenv("PINECONE_ENV")
 
+        self.image_provider = os.getenv("IMAGE_PROVIDER")
         self.huggingface_api_token = os.getenv("HUGGINGFACE_API_TOKEN")
 
         # User agent headers to use when browsing web

--- a/scripts/data/prompt.txt
+++ b/scripts/data/prompt.txt
@@ -23,6 +23,7 @@ COMMANDS:
 17. Write Tests: "write_tests", args: "code": "<full_code_string>", "focus": "<list_of_focus_areas>"
 18. Execute Python File: "execute_python_file", args: "file": "<file>"
 19. Task Complete (Shutdown): "task_complete", args: "reason": "<reason>"
+20. Generate Image: "generate_image", args: "prompt": "<prompt>"
 
 RESOURCES:
 

--- a/scripts/image_gen.py
+++ b/scripts/image_gen.py
@@ -1,0 +1,44 @@
+from kandinsky2 import get_kandinsky2
+from config import Config
+
+cfg = Config()
+
+def generate_image(prompt):
+        
+    model = get_kandinsky2('cuda', task_type='text2img', model_version='2.1', use_flash_attention=False)
+    images = model.generate_text2img(
+        "red cat, 4k photo", # prompt
+        num_steps=100,
+        batch_size=1, 
+        guidance_scale=4,
+        h=768, w=768,
+        sampler='p_sampler', 
+        prior_cf_scale=4,
+        prior_steps="5"
+    )
+    return images
+    
+    # base_url = 'http://export.arxiv.org/api/query?'
+    # query = f'search_query=all:{search_query}&start=0&max_results={max_results}'
+    # url = base_url + query
+    # response = requests.get(url)
+
+    # if response.status_code == 200:
+    #     soup = BeautifulSoup(response.content, 'xml')
+    #     entries = soup.find_all('entry')
+
+    #     articles = []
+    #     for entry in entries:
+    #         title = entry.title.text.strip()
+    #         url = entry.id.text.strip()
+    #         published = entry.published.text.strip()
+
+    #         articles.append({
+    #             'title': title,
+    #             'url': url,
+    #             'published': published
+    #         })
+
+    #     return articles
+    # else:
+    #     return None

--- a/scripts/image_gen.py
+++ b/scripts/image_gen.py
@@ -4,6 +4,8 @@ import os.path
 from PIL import Image
 from config import Config
 import uuid
+import openai
+from base64 import b64decode
 
 cfg = Config()
 
@@ -13,16 +15,36 @@ API_URL = "https://api-inference.huggingface.co/models/CompVis/stable-diffusion-
 headers = {"Authorization": "Bearer " + cfg.huggingface_api_token}
 
 def generate_image(prompt):
+
+    filename = str(uuid.uuid4()) + ".jpg"
+
+    # DALL-E
+    openai.api_key = cfg.openai_api_key
+
+    response = openai.Image.create(
+        prompt=prompt,
+        n=1,
+        size="256x256",
+        response_format="b64_json",
+    )
+
+    print("Image Generated for prompt:" + prompt)
+    print(response["data"][0]["b64_json"][:50])
+
+    image_data = b64decode(response["data"][0]["b64_json"])
+    with open(working_directory + "/" + filename, mode="wb") as png:
+        png.write(image_data)
+
+    return "Saved to disk:" + filename
+
+    # STABLE DIFFUSION
     response = requests.post(API_URL, headers=headers, json={
         "inputs": prompt,
     })
     image = Image.open(io.BytesIO(response.content))
     print("Image Generated for prompt:" + prompt)
 
-    filename = str(uuid.uuid4()) + ".jpg"
-
     image.save(os.path.join(working_directory, filename))
-
     print("Saved to disk:" + filename)
 
     return str("Image " + filename + " saved to disk for prompt: " + prompt)

--- a/scripts/image_gen.py
+++ b/scripts/image_gen.py
@@ -17,7 +17,7 @@ def generate_image(prompt):
     
     # DALL-E
     if cfg.image_provider == 'dalle':
-        
+
         openai.api_key = cfg.openai_api_key
 
         response = openai.Image.create(
@@ -28,7 +28,6 @@ def generate_image(prompt):
         )
 
         print("Image Generated for prompt:" + prompt)
-        print(response["data"][0]["b64_json"][:50])
 
         image_data = b64decode(response["data"][0]["b64_json"])
 
@@ -51,9 +50,8 @@ def generate_image(prompt):
         print("Image Generated for prompt:" + prompt)
 
         image.save(os.path.join(working_directory, filename))
-        print("Saved to disk:" + filename)
 
-        return str("Image " + filename + " saved to disk for prompt: " + prompt)
+        return "Saved to disk:" + filename
 
     else:
         return "No Image Provider Set"


### PR DESCRIPTION
### Background

Adds support for DALL-e (default) and Stable Diffusion. Image providers can be switched via the `IMAGE_PROVIDER` env var.

### Changes

Adds a command for `generate_image` and a corresponding handler. 
Adds support for DALL-e and Stable Diffusion (via API).
Leverages the existing openAI API Key for DALL-e.

### Test Plan

Tested against multiple prompts, was even able to get it to generate articles and include the generated images into the articles(!!) 
![telegram-cloud-photo-size-1-5008322189925133222-x](https://user-images.githubusercontent.com/42594751/230668838-6289ec7d-0db0-4de1-8519-ab01435493ad.jpg)


### Change Safety

- [ ] I have added tests to cover my changes
- [ x] I have considered potential risks and mitigations for my changes

I am not sure how to test python code in this project.
