### PR TITLE
Pinecone API Key Bug Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Your support is greatly appreciated
 ## 📋 Requirements
 - [Python 3.7 or later](https://www.tutorialspoint.com/how-to-install-python-in-windows)
 - OpenAI API key
+- PINECONE API key
 
 Optional:
 - ElevenLabs Key (If you want the AI to speak)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -281,11 +281,12 @@ next_action_count = 0
 # Make a constant:
 user_input = "Determine which next command to use, and respond using the format specified above:"
 
+# raise an exception if pinecone_api_key or region is not provided
+if not cfg.pinecone_api_key or not cfg.pinecone_region: raise Exception("Please provide pinecone_api_key and pinecone_region")
 # Initialize memory and make sure it is empty.
 # this is particularly important for indexing and referencing pinecone memory
 memory = PineconeMemory()
 memory.clear()
-
 print('Using memory of type: ' + memory.__class__.__name__)
 
 # Interaction Loop


### PR DESCRIPTION
### Background

- This PR provides fix to issue #433
- The issue is basically if you don't provide Pinecone API or Pinecone ENV then the main.py module raises an error.
- Therefore Pinecone is necessary for the main.py module to work.

### Changes

- I added an exception in main.py before initializing the Pinecone Memory instance. The exception is raised if either pinecone_api_key or pinecone_region is not provided in env.
- Consequently, I also update the README.md as well to reflect the updated requirements.

No new tests were needed.


