### PR TITLE
Made Token Limit and Model Configurable rather than hard coded

### DIFF
--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -47,6 +47,7 @@ def chat_with_ai(
         full_message_history,
         permanent_memory,
         token_limit,
+        model,
         debug=False):
     while True:
         try:
@@ -59,11 +60,10 @@ def chat_with_ai(
             full_message_history (list): The list of all messages sent between the user and the AI.
             permanent_memory (Obj): The memory object containing the permanent memory.
             token_limit (int): The maximum number of tokens allowed in the API call.
-
+            model_type(str): The type of model to use: gpt-3.5-turbo or gpt-4
             Returns:
             str: The AI's response.
             """
-            model = cfg.fast_llm_model # TODO: Change model from hardcode to argument
             # Reserve 1000 tokens for the response
             if debug:
                 print(f"Token limit: {token_limit}")

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -39,7 +39,7 @@ class Config(metaclass=Singleton):
         self.smart_llm_model = os.getenv("SMART_LLM_MODEL", "gpt-4")
         self.fast_token_limit = int(os.getenv("FAST_TOKEN_LIMIT", 4000))
         self.smart_token_limit = int(os.getenv("SMART_TOKEN_LIMIT", 8000))
-        
+        self.gpt3only = False
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
         self.use_azure = False
         self.use_azure = os.getenv("USE_AZURE") == 'True'
@@ -114,3 +114,6 @@ class Config(metaclass=Singleton):
 
     def set_debug_mode(self, value: bool):
         self.debug = value
+    
+    def set_gpt3_only(self, value:bool):
+        self.gpt3only = value

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -264,7 +264,7 @@ def parse_arguments():
 
     if args.gpt3only:
         print_to_console("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")
-        cfg.set_smart_llm_model(cfg.fast_llm_model)
+        cfg.set_gpt3_only(True)
 
     if args.debug:
         print_to_console("Debug Mode: ", Fore.GREEN, "ENABLED")
@@ -292,6 +292,9 @@ print('Using memory of type: ' + memory.__class__.__name__)
 
 # Interaction Loop
 while True:
+    # Setting up the token limit and model type according to model type
+    token_limit = (cfg.fast_token_limit if cfg.gpt3only else cfg.smart_token_limit)
+    model = (cfg.fast_llm_model if cfg.gpt3only else cfg.smart_llm_model)
     # Send message to AI, get response
     with Spinner("Thinking... "):
         assistant_reply = chat.chat_with_ai(
@@ -299,7 +302,9 @@ while True:
             user_input,
             full_message_history,
             memory,
-            cfg.fast_token_limit, cfg.debug) # TODO: This hardcodes the model to use GPT3.5. Make this an argument
+            token_limit,
+            model,
+            cfg.debug)
 
     # Print Assistant thoughts
     print_assistant_thoughts(assistant_reply)


### PR DESCRIPTION
### Background
The token limit was hardcoded in the chat_with_ai function which was also identified as a TODO in the code.

### Changes
The token limit was made configurable according to whether the user passed gpt3only or not.

No tests were needed for this change since it was more of a chore rather a feat update.