### PR TITLE
gitignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ package-lock.json
 auto_gpt_workspace/*
 *.mpeg
 .env
+venv/*
 outputs/*
 ai_settings.yaml


### PR DESCRIPTION
### Background
Users frequently utilise python's venv module to isolate per-project dependencies.  

### Changes
This change adds a .gitignore entry for default venv name 'venv' in the project root. 

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ n/a] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as seperate Pull Reqests, they are the easiest to merge! -->

