### PR TITLE
[Quick fix] Make `do_nothing` line uniform

### DIFF
--- a/scripts/data/prompt.txt
+++ b/scripts/data/prompt.txt
@@ -24,7 +24,7 @@ COMMANDS:
 18. Execute Python File: "execute_python_file", args: "file": "<file>"
 19. Task Complete (Shutdown): "task_complete", args: "reason": "<reason>"
 20. Generate Image: "generate_image", args: "prompt": "<prompt>"
-21. Do Nothing; command name: "do_nothing", args: ""
+21. Do Nothing: "do_nothing", args: ""
 
 RESOURCES:
 


### PR DESCRIPTION
### Background
https://github.com/Torantulino/Auto-GPT/pull/575#discussion_r1161529687

### Changes
Makes the `do_nothing` line in `prompt.txt` from my last pull request (#575) completely uniform with the rest of the commands list. 

### Documentation
Removed `; command name` from said line.

### Test Plan
Already tested in #575.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as seperate Pull Reqests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
