### PR TITLE
Re-order cfg declaration before utilizing it

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -291,8 +291,8 @@ def parse_arguments():
 
 
 # TODO: fill in llm values here
-check_openai_api_key()
 cfg = Config()
+check_openai_api_key()
 parse_arguments()
 ai_name = ""
 prompt = construct_prompt()


### PR DESCRIPTION
<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
Ref #672 the program currently crashes on launch when attempting to call cfg before the variable is declared.

### Changes
The change moves the declaration of the cfg-variable to right above the check_openapi_api_key function call, ensuring that the variable exists before it's read.

### Documentation
None

### Test Plan
None

### PR Quality Checklist
- [ x ] My pull request is atomic and focuses on a single change.
- [ x ] I have thouroughly tested my changes with multiple different prompts.
- [ x ] I have considered potential risks and mitigations for my changes.
- [ x ] I have documented my changes clearly and comprehensively.
- [ x ] I have not snuck in any "extra" small tweaks changes

No tests added as the change is minor and has no side-effects.

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
