### PR TITLE
Fix various JSON input bugs

### DIFF
--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -26,7 +26,7 @@ JSON_SCHEMA = """
 """
 
 
-def fix_and_parse_json(    
+def fix_and_parse_json(
     json_str: str,
     try_to_fix_with_gpt: bool = True
 ) -> Union[str, Dict[Any, Any]]:
@@ -35,8 +35,8 @@ def fix_and_parse_json(
         json_str = json_str.replace('\t', '')
         return json.loads(json_str)
     except json.JSONDecodeError as _:  # noqa: F841
-        json_str = correct_json(json_str)
         try:
+            json_str = correct_json(json_str)
             return json.loads(json_str)
         except json.JSONDecodeError as _:  # noqa: F841
             pass
@@ -53,6 +53,7 @@ def fix_and_parse_json(
         last_brace_index = json_str.rindex("}")
         json_str = json_str[:last_brace_index+1]
         return json.loads(json_str)
+    # Can throw a ValueError if there is no "{" or "}" in the json_str
     except (json.JSONDecodeError, ValueError) as e:  # noqa: F841
         if try_to_fix_with_gpt:
             print("Warning: Failed to parse AI output, attempting to fix."


### PR DESCRIPTION
### Background
I was receiving an `Invalid JSON` error on pretty much every prompt. Once it was received, it was very difficult to get out of it.

### Changes
By not having correct_json(json_str) in the try/except, it was still easily possible to throw Invalid JSON errors.

When responses were received with no JSON at all, parsing would fail on attempting to locate the braces.

### Test Plan
Tested by running a bunch of prompts. Sorry it's not more scientific than that. Each time I got a parsing error, I added a fix, and now it seems stable.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as seperate Pull Reqests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
