### PR TITLE
Remove unnecessary assignments

### DIFF
--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -42,9 +42,6 @@ def get_command(response):
         # Use an empty dictionary if 'args' field is not present in 'command' object
         arguments = command.get("args", {})
 
-        if not arguments:
-            arguments = {}
-
         return command_name, arguments
     except json.decoder.JSONDecodeError:
         return "Error:", "Invalid JSON"


### PR DESCRIPTION
### Background

Since the default value of the arguments variable is specified as `{}` on line 43, I consider this assignment to be unnecessary

### Changes

Remove unnecessary assignments

### Documentation

No changes

### Test Plan

I didn't add the test because it's a trivial matter.