### PR TITLE
Remove trailing whitespace throughout

### DIFF
--- a/scripts/ai_config.py
+++ b/scripts/ai_config.py
@@ -34,7 +34,7 @@ class AIConfig:
     @classmethod
     def load(cls: object, config_file: str=SAVE_FILE) -> object:
         """
-        Returns class object with parameters (ai_name, ai_role, ai_goals) loaded from yaml file if yaml file exists, 
+        Returns class object with parameters (ai_name, ai_role, ai_goals) loaded from yaml file if yaml file exists,
         else returns class with no parameters.
 
         Parameters:
@@ -42,7 +42,7 @@ class AIConfig:
            config_file (int): The path to the config yaml file. DEFAULT: "../ai_settings.yaml"
 
         Returns:
-            cls (object): A instance of given cls object  
+            cls (object): A instance of given cls object
         """
 
         try:
@@ -61,11 +61,11 @@ class AIConfig:
         """
         Saves the class parameters to the specified file yaml file path as a yaml file.
 
-        Parameters: 
+        Parameters:
             config_file(str): The path to the config yaml file. DEFAULT: "../ai_settings.yaml"
 
         Returns:
-            None 
+            None
         """
 
         config = {"ai_name": self.ai_name, "ai_role": self.ai_role, "ai_goals": self.ai_goals}
@@ -76,7 +76,7 @@ class AIConfig:
         """
         Returns a prompt to the user with the class information in an organized fashion.
 
-        Parameters: 
+        Parameters:
             None
 
         Returns:

--- a/scripts/ai_functions.py
+++ b/scripts/ai_functions.py
@@ -27,7 +27,7 @@ def evaluate_code(code: str) -> List[str]:
 
 def improve_code(suggestions: List[str], code: str) -> str:
     """
-    A function that takes in code and suggestions and returns a response from create chat completion api call. 
+    A function that takes in code and suggestions and returns a response from create chat completion api call.
 
     Parameters:
         suggestions (List): A list of suggestions around what needs to be improved.

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -37,7 +37,7 @@ class Config(metaclass=Singleton):
         self.continuous_mode = False
         self.speak_mode = False
 
-        self.fast_llm_model = os.getenv("FAST_LLM_MODEL", "gpt-3.5-turbo") 
+        self.fast_llm_model = os.getenv("FAST_LLM_MODEL", "gpt-3.5-turbo")
         self.smart_llm_model = os.getenv("SMART_LLM_MODEL", "gpt-4")
         self.fast_token_limit = int(os.getenv("FAST_TOKEN_LIMIT", 4000))
         self.smart_token_limit = int(os.getenv("SMART_TOKEN_LIMIT", 8000))

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -281,7 +281,7 @@ def parse_arguments():
 
     if args.debug:
         print_to_console("Debug Mode: ", Fore.GREEN, "ENABLED")
-        cfg.set_debug_mode(True)        
+        cfg.set_debug_mode(True)
 
     if args.gpt3only:
         print_to_console("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")

--- a/tests/test_browse_scrape_text.py
+++ b/tests/test_browse_scrape_text.py
@@ -37,7 +37,7 @@ Additional aspects:
 
 class TestScrapeText:
 
-    # Tests that scrape_text() returns the expected text when given a valid URL. 
+    # Tests that scrape_text() returns the expected text when given a valid URL.
     def test_scrape_text_with_valid_url(self, mocker):
         # Mock the requests.get() method to return a response with expected text
         expected_text = "This is some sample text"
@@ -50,7 +50,7 @@ class TestScrapeText:
         url = "http://www.example.com"
         assert scrape_text(url) == expected_text
 
-    # Tests that the function returns an error message when an invalid or unreachable url is provided. 
+    # Tests that the function returns an error message when an invalid or unreachable url is provided.
     def test_invalid_url(self, mocker):
         # Mock the requests.get() method to raise an exception
         mocker.patch("requests.get", side_effect=requests.exceptions.RequestException)
@@ -60,7 +60,7 @@ class TestScrapeText:
         error_message = scrape_text(url)
         assert "Error:" in error_message
 
-    # Tests that the function returns an empty string when the html page contains no text to be scraped. 
+    # Tests that the function returns an empty string when the html page contains no text to be scraped.
     def test_no_text(self, mocker):
         # Mock the requests.get() method to return a response with no text
         mock_response = mocker.Mock()
@@ -72,7 +72,7 @@ class TestScrapeText:
         url = "http://www.example.com"
         assert scrape_text(url) == ""
 
-    # Tests that the function returns an error message when the response status code is an http error (>=400).  
+    # Tests that the function returns an error message when the response status code is an http error (>=400).
     def test_http_error(self, mocker):
         # Mock the requests.get() method to return a response with a 404 status code
         mocker.patch('requests.get', return_value=mocker.Mock(status_code=404))
@@ -83,7 +83,7 @@ class TestScrapeText:
         # Check that the function returns an error message
         assert result == "Error: HTTP 404 error"
 
-    # Tests that scrape_text() properly handles HTML tags. 
+    # Tests that scrape_text() properly handles HTML tags.
     def test_scrape_text_with_html_tags(self, mocker):
         # Create a mock response object with HTML containing tags
         html = "<html><body><p>This is <b>bold</b> text.</p></body></html>"


### PR DESCRIPTION
### Background

This is a new instance of #590. After many merged PR the trailing space creeped in again.

### Changes

Only space characters at EOL were trimmed, and in the edited files the ending \r\n was added automaticall by vim (which is a good thing)

### Documentation

N/A

### Test Plan

N/A

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as seperate Pull Reqests, they are the easiest to merge! -->