### PR TITLE
Fix flake8 W293 and W391

### DIFF
--- a/scripts/ai_config.py
+++ b/scripts/ai_config.py
@@ -92,4 +92,3 @@ class AIConfig:
 
         full_prompt += f"\n\n{data.load_prompt()}"
         return full_prompt
-

--- a/scripts/browse.py
+++ b/scripts/browse.py
@@ -15,7 +15,7 @@ def scrape_text(url):
     # Most basic check if the URL is valid:
     if not url.startswith('http'):
         return "Error: Invalid URL"
-    
+
     # Restrict access to local files
     if check_local_file_access(url):
         return "Error: Access to local files is restricted"

--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -63,10 +63,10 @@ def chat_with_ai(
             """
             model = cfg.fast_llm_model # TODO: Change model from hardcode to argument
             # Reserve 1000 tokens for the response
-            
+
             if cfg.debug:
                 print(f"Token limit: {token_limit}")
-                
+
             send_token_limit = token_limit - 1000
 
             relevant_memory = permanent_memory.get_relevant(str(full_message_history[-5:]), 10)

--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -71,11 +71,11 @@ def fix_and_parse_json(
                 return json_str
         else:
             raise e
-            
-        
+
+
 def fix_json(json_str: str, schema: str) -> str:
     """Fix the given JSON string to make it parseable and fully complient with the provided schema."""
-    
+
     # Try to fix the JSON using gpt:
     function_string = "def fix_json(json_str: str, schema:str=None) -> str:"
     args = [f"'''{json_str}'''", f"'''{schema}'''"]

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -415,4 +415,3 @@ while True:
             chat.create_chat_message(
                 "system", "Unable to execute command"))
         print_to_console("SYSTEM: ", Fore.YELLOW, "Unable to execute command")
-


### PR DESCRIPTION
### Background

This is a part of a large movement to enable flake8 without breaking things.

### Changes

Fix 2 flake 8 warnings: empty lines with whitespace and empty lines at the end of a file. There are not many fixes, so that it's easy to review and merge, and it isn't likely to break the existing PRs.

### Documentation

N/A

### Test Plan

N/A

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as seperate Pull Reqests, they are the easiest to merge! -->