### PR TITLE
GPT-4 Only Option

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -265,6 +265,7 @@ def parse_arguments():
     parser.add_argument('--speak', action='store_true', help='Enable Speak Mode')
     parser.add_argument('--debug', action='store_true', help='Enable Debug Mode')
     parser.add_argument('--gpt3only', action='store_true', help='Enable GPT3.5 Only Mode')
+    parser.add_argument('--gpt4only', action='store_true', help='Enable GPT4 Only Mode')
     args = parser.parse_args()
 
     if args.continuous:
@@ -286,6 +287,10 @@ def parse_arguments():
     if args.gpt3only:
         print_to_console("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")
         cfg.set_smart_llm_model(cfg.fast_llm_model)
+    
+    if args.gpt4only:
+        print_to_console("GPT4 Only Mode: ", Fore.GREEN, "ENABLED")
+        cfg.set_fast_llm_model(cfg.smart_llm_model)
 
     if args.debug:
         print_to_console("Debug Mode: ", Fore.GREEN, "ENABLED")


### PR DESCRIPTION
### Background

There was no option that allowed the model to run in GPT-4 only mode.

### Changes

Changed `main.py` module. `parse_argument` function was modified and the `gpt4only` argument was added to the parser. If `gpt4only` is provided by the user then fast_llm_model is set to smart_llm_model just like vice versa is happening in gpt3only mode.

### Documentation

No additional documentation was needed.

### Test Plan

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 