### PR TITLE
Fix case where index throws value error.

### DIFF
--- a/scripts/json_parser.py
+++ b/scripts/json_parser.py
@@ -53,7 +53,7 @@ def fix_and_parse_json(
         last_brace_index = json_str.rindex("}")
         json_str = json_str[:last_brace_index+1]
         return json.loads(json_str)
-    except json.JSONDecodeError as e:  # noqa: F841
+    except (json.JSONDecodeError, ValueError) as e:  # noqa: F841
         if try_to_fix_with_gpt:
             print("Warning: Failed to parse AI output, attempting to fix."
                   "\n If you see this warning frequently, it's likely that"


### PR DESCRIPTION

### Background

This block was not running due to the above code not letting it, it now throws a value error if the index was not found.
![image](https://user-images.githubusercontent.com/34168009/231044421-b4a38db7-a204-4909-b144-2b9e1db9f522.png)

### Changes

Add additional exception `ValueError` to except statement.

### Documentation

None

### Test Plan
None

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 
