### PR TITLE
update gitignore venv/* to *venv/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ package-lock.json
 auto_gpt_workspace/*
 *.mpeg
 .env
-venv/*
+*venv/*
 outputs/*
 ai_settings.yaml
 .vscode


### PR DESCRIPTION
### Background
issue: #767

### Changes
Changes line 10 in the .gitignore from `venv/*` to `*venv/*`

### Documentation
Such a simple change is self-explanatory, not worth the clutter of a comment line in the `.gitignore`. It would be better to add a section about venv in the `README`, these should be a different PR, not this one.

### Test Plan
I tested this PR by naming my virtual environment `Auto-GPT-venv`, then pushed to a branch and confirmed the virtual environment directory was ignored.

### PR Quality Checklist

- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes

Thanks, gn.