### PR TITLE
Remove duplicates of set debug mode func

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -89,9 +89,6 @@ class Config(metaclass=Singleton):
         """Set the speak mode value."""
         self.speak_mode = value
 
-    def set_debug_mode(self, value: bool):
-        self.debug_mode = value
-
     def set_fast_llm_model(self, value: str):
         """Set the fast LLM model value."""
         self.fast_llm_model = value

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -288,10 +288,6 @@ def parse_arguments():
         print_to_console("Speak Mode: ", Fore.GREEN, "ENABLED")
         cfg.set_speak_mode(True)
 
-    if args.debug:
-        print_to_console("Debug Mode: ", Fore.GREEN, "ENABLED")
-        cfg.set_debug_mode(True)
-
     if args.gpt3only:
         print_to_console("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")
         cfg.set_smart_llm_model(cfg.fast_llm_model)


### PR DESCRIPTION
Another attempt to remove the duplicate set debug mode func in the current HEAD.
It has been hard to get removed because of multiple pull requests and conflicts.