### PR TITLE
Ensure docker build cache used for pip install unless requirements.txt changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.11
 
+
+WORKDIR /tmp
+COPY requirements.txt /tmp
+RUN pip install -r requirements.txt
+
 WORKDIR /app
 COPY scripts/ /app
-COPY requirements.txt /app
-
-RUN pip install -r requirements.txt
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
### Background
I noticed that making changes to code in the scripts dir caused the `pip install` line in the Dockerfile to miss the cache and run again. This make rebuilding the image unecessarily slow since the only reason to invalidate the cache for that step of the build is when requirements.txt has been modified.

### Changes
* requirements.txt is now copied into the /tmp directory where `pip install` is run
* the scripts directory is now copied into the image after `pip install` so that changes there no longer invalidate the build cache

### Documentation
n/a

### Test Plan
I verified that the cache is no longer invalidated and that the image generated behaves the same.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 
