### PR TITLE
Add docker compose scheduling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+# To boot the app run the following:
+# docker-compose run auto-gpt
+version: "3.9"
+
+services:
+  auto-gpt:
+    depends_on:
+      - redis
+    build: ./
+    volumes:
+      - "./scripts:/app"
+      - ".env:/app/.env"
+    profiles: ["exclude-from-up"]
+
+  redis:
+    image: "redis/redis-stack-server:latest"


### PR DESCRIPTION
### Background
Add docker compose so that getting the app running with redis is one command:

```
docker-compose run auto-gpt
```

### Changes
Introduced a `docker-compose.yml` configuration file that achieves the above

### Documentation
n/a

### Test Plan
n/a

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thouroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes