### PR TITLE
fix AttributeError: 'Config' object has no attribute 'debug'

### DIFF
--- a/scripts/chat.py
+++ b/scripts/chat.py
@@ -64,14 +64,14 @@ def chat_with_ai(
             model = cfg.fast_llm_model # TODO: Change model from hardcode to argument
             # Reserve 1000 tokens for the response
 
-            if cfg.debug:
+            if cfg.debug_mode:
                 print(f"Token limit: {token_limit}")
 
             send_token_limit = token_limit - 1000
 
             relevant_memory = permanent_memory.get_relevant(str(full_message_history[-5:]), 10)
 
-            if cfg.debug:
+            if cfg.debug_mode:
                 print('Memory Stats: ', permanent_memory.get_stats())
 
             next_message_to_add_index, current_tokens_used, insertion_index, current_context = generate_context(
@@ -110,7 +110,7 @@ def chat_with_ai(
             # assert tokens_remaining >= 0, "Tokens remaining is negative. This should never happen, please submit a bug report at https://www.github.com/Torantulino/Auto-GPT"
 
             # Debug print the current context
-            if cfg.debug:
+            if cfg.debug_mode:
                 print(f"Token limit: {token_limit}")
                 print(f"Send Token Count: {current_tokens_used}")
                 print(f"Tokens remaining for response: {tokens_remaining}")


### PR DESCRIPTION
I had the following error:

```sh
$ python3 scripts/main.py
Welcome back!  Would you like me to return to being Entrepreneur-GPT?
Continue with the last settings?
Name:  Entrepreneur-GPT
Role:  an AI designed to autonomously develop and run businesses with the sole goal of increasing your net worth.
Goals: ['Increase net worth.', 'Develop and manage multiple businesses autonomously.', 'Play to your strengths as a Large Language Model.']
Continue (y/n): y
Using memory of type: LocalCache
Traceback (most recent call last):
  File "/REDACTED/Auto-GPT/scripts/main.py", line 321, in <module>
    assistant_reply = chat.chat_with_ai(
  File "/REDACTED/Auto-GPT/scripts/chat.py", line 74, in chat_with_ai
    if cfg.debug:
AttributeError: 'Config' object has no attribute 'debug'
```

I fixed it by renaming `debug` to `debug_mode` if that makes sense.