### PR TITLE
Use UTF-8 encoding for reading config file.

### DIFF
--- a/scripts/ai_config.py
+++ b/scripts/ai_config.py
@@ -46,7 +46,7 @@ class AIConfig:
         """
 
         try:
-            with open(config_file) as file:
+            with open(config_file, encoding='utf-8') as file:
                 config_params = yaml.load(file, Loader=yaml.FullLoader)
         except FileNotFoundError:
             config_params = {}


### PR DESCRIPTION
### Background
Errors may occur when inputting Chinese characters into `ai_setting.yaml` due to encoding issues.

>UnicodeDecodeError: 'gbk' codec can't decode byte 0xae in position 14: illegal multibyte sequence

### Changes

Read config files with UTF-8 encoding.


### Documentation

No need to document.


### Test Plan

Tested locally & No need to add testcase.


### PR Quality Checklist

- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes