### PR TITLE
Improved logging on connection fail to a Memory Backend

### DIFF
--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -123,12 +123,13 @@ class Logger(metaclass=Singleton):
     def set_level(self, level):
         self.logger.setLevel(level)
         self.typing_logger.setLevel(level)
-    
+
     def double_check(self, additionalText=None):
         if not additionalText:
             additionalText = "Please ensure you've setup and configured everything correctly. Read https://github.com/Torantulino/Auto-GPT#readme to double check. You can also create a github issue or join the discord and ask there!"
 
         self.typewriter_log("DOUBLE CHECK CONFIGURATION", Fore.YELLOW, additionalText)
+
 
 '''
 Output stream to console using simulated typing

--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -123,7 +123,12 @@ class Logger(metaclass=Singleton):
     def set_level(self, level):
         self.logger.setLevel(level)
         self.typing_logger.setLevel(level)
+    
+    def double_check(self, additionalText=None):
+        if not additionalText:
+            additionalText = "Please ensure you've setup and configured everything correctly. Read https://github.com/Torantulino/Auto-GPT#readme to double check. You can also create a github issue or join the discord and ask there!"
 
+        self.typewriter_log("DOUBLE CHECK CONFIGURATION", Fore.YELLOW, additionalText)
 
 '''
 Output stream to console using simulated typing

--- a/scripts/memory/pinecone.py
+++ b/scripts/memory/pinecone.py
@@ -3,7 +3,7 @@ import pinecone
 
 from memory.base import MemoryProviderSingleton, get_ada_embedding
 from logger import logger
-from colorama import Fore, Style 
+from colorama import Fore, Style
 
 class PineconeMemory(MemoryProviderSingleton):
     def __init__(self, cfg):
@@ -17,7 +17,7 @@ class PineconeMemory(MemoryProviderSingleton):
         # this assumes we don't start with memory.
         # for now this works.
         # we'll need a more complicated and robust system if we want to start with memory.
-        self.vec_num = 0    
+        self.vec_num = 0
 
         try:
             pinecone.whoami()

--- a/scripts/memory/pinecone.py
+++ b/scripts/memory/pinecone.py
@@ -23,10 +23,8 @@ class PineconeMemory(MemoryProviderSingleton):
             pinecone.whoami()
         except Exception as e:
             logger.typewriter_log("FAILED TO CONNECT TO PINECONE", Fore.RED, Style.BRIGHT + str(e) + Style.RESET_ALL)
-            logger.typewriter_log("DOUBLE CHECK CONFIGURATION", 
-                                  Fore.YELLOW, 
-                                    "Please ensure you have setup and configured Pinecone properly for use. " +
-                                   f"You can check out {Fore.CYAN + Style.BRIGHT}https://github.com/Torantulino/Auto-GPT#-pinecone-api-key-setup{Style.RESET_ALL} to ensure you've set up everything correctly.")
+            logger.double_check("Please ensure you have setup and configured Pinecone properly for use. " +
+                               f"You can check out {Fore.CYAN + Style.BRIGHT}https://github.com/Torantulino/Auto-GPT#-pinecone-api-key-setup{Style.RESET_ALL} to ensure you've set up everything correctly.")
             exit(1)
 
         if table_name not in pinecone.list_indexes():

--- a/scripts/memory/pinecone.py
+++ b/scripts/memory/pinecone.py
@@ -2,7 +2,8 @@
 import pinecone
 
 from memory.base import MemoryProviderSingleton, get_ada_embedding
-
+from logger import logger
+from colorama import Fore, Style 
 
 class PineconeMemory(MemoryProviderSingleton):
     def __init__(self, cfg):
@@ -16,7 +17,18 @@ class PineconeMemory(MemoryProviderSingleton):
         # this assumes we don't start with memory.
         # for now this works.
         # we'll need a more complicated and robust system if we want to start with memory.
-        self.vec_num = 0
+        self.vec_num = 0    
+
+        try:
+            pinecone.whoami()
+        except Exception as e:
+            logger.typewriter_log("FAILED TO CONNECT TO PINECONE", Fore.RED, Style.BRIGHT + str(e) + Style.RESET_ALL)
+            logger.typewriter_log("DOUBLE CHECK CONFIGURATION", 
+                                  Fore.YELLOW, 
+                                    "Please ensure you have setup and configured Pinecone properly for use. " +
+                                   f"You can check out {Fore.CYAN + Style.BRIGHT}https://github.com/Torantulino/Auto-GPT#-pinecone-api-key-setup{Style.RESET_ALL} to ensure you've set up everything correctly.")
+            exit(1)
+
         if table_name not in pinecone.list_indexes():
             pinecone.create_index(table_name, dimension=dimension, metric=metric, pod_type=pod_type)
         self.index = pinecone.Index(table_name)

--- a/scripts/memory/redismem.py
+++ b/scripts/memory/redismem.py
@@ -54,7 +54,7 @@ class RedisMemory(MemoryProviderSingleton):
             logger.typewriter_log("FAILED TO CONNECT TO REDIS", Fore.RED, Style.BRIGHT + str(e) + Style.RESET_ALL)
             logger.typewriter_log("DOUBLE CHECK CONFIGURATION", 
                                   Fore.YELLOW, 
-                                    "Please ensure you have setup and configured redis properly for use. " +
+                                    "Please ensure you have setup and configured Redis properly for use. " +
                                    f"You can check out {Fore.CYAN + Style.BRIGHT}https://github.com/Torantulino/Auto-GPT#redis-setup{Style.RESET_ALL} to ensure you've set up everything correctly.")
             exit(1)
 

--- a/scripts/memory/redismem.py
+++ b/scripts/memory/redismem.py
@@ -7,6 +7,8 @@ from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 import numpy as np
 
 from memory.base import MemoryProviderSingleton, get_ada_embedding
+from logger import logger
+from colorama import Fore, Style 
 
 
 SCHEMA = [
@@ -44,6 +46,18 @@ class RedisMemory(MemoryProviderSingleton):
             db=0  # Cannot be changed
         )
         self.cfg = cfg
+
+        # Check redis connection
+        try:
+            self.redis.ping()
+        except redis.ConnectionError as e:
+            logger.typewriter_log("FAILED TO CONNECT TO REDIS", Fore.RED, Style.BRIGHT + str(e) + Style.RESET_ALL)
+            logger.typewriter_log("DOUBLE CHECK CONFIGURATION", 
+                                  Fore.YELLOW, 
+                                    "Please ensure you have setup and configured redis properly for use. " +
+                                   f"You can check out {Fore.CYAN + Style.BRIGHT}https://github.com/Torantulino/Auto-GPT#redis-setup{Style.RESET_ALL} to ensure you've set up everything correctly.")
+            exit(1)
+
         if cfg.wipe_redis_on_start:
             self.redis.flushall()
         try:

--- a/scripts/memory/redismem.py
+++ b/scripts/memory/redismem.py
@@ -52,10 +52,8 @@ class RedisMemory(MemoryProviderSingleton):
             self.redis.ping()
         except redis.ConnectionError as e:
             logger.typewriter_log("FAILED TO CONNECT TO REDIS", Fore.RED, Style.BRIGHT + str(e) + Style.RESET_ALL)
-            logger.typewriter_log("DOUBLE CHECK CONFIGURATION", 
-                                  Fore.YELLOW, 
-                                    "Please ensure you have setup and configured Redis properly for use. " +
-                                   f"You can check out {Fore.CYAN + Style.BRIGHT}https://github.com/Torantulino/Auto-GPT#redis-setup{Style.RESET_ALL} to ensure you've set up everything correctly.")
+            logger.double_check("Please ensure you have setup and configured Redis properly for use. " +
+                                f"You can check out {Fore.CYAN + Style.BRIGHT}https://github.com/Torantulino/Auto-GPT#redis-setup{Style.RESET_ALL} to ensure you've set up everything correctly.")
             exit(1)
 
         if cfg.wipe_redis_on_start:

--- a/scripts/memory/redismem.py
+++ b/scripts/memory/redismem.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from memory.base import MemoryProviderSingleton, get_ada_embedding
 from logger import logger
-from colorama import Fore, Style 
+from colorama import Fore, Style
 
 
 SCHEMA = [


### PR DESCRIPTION
<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
When AutoGPT attempts to connect to Redis or Pinecone, it doesn't check if the connection actually works. If it doesn't work a nasty exception is outputted, which can be annoying or overwhelming for new users.

### Changes
Before performing any commands on Redis, Auto-GPT calls `redis.ping()` to verify the connection. If the connection doesn't work for whatever reason, Auto-GPT will log the following lines to the user:
```
FAILED TO CONNECT TO REDIS  Error 10061 connecting to localhost:6379. No connection could be made because the target machine actively refused it.
DOUBLE CHECK CONFIGURATION  Please ensure you have setup and configured Redis properly for use. You can check out https://github.com/Torantulino/Auto-GPT#redis-setup to ensure you've set up everything correctly.
```
For pinecone, Auto-GPT will confirm the user's credentials with `pinecone.whoami()`. And a similar thing occurs if an exception is raised. 

### Test Plan
I have tested the functionality of this PR by attempting to connect to redis while not having it running/installed and Pinecone with missing/false credentials. If anyone has any comments on helping further test this if needed, then please tell me.


### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Reqests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
