### PR TITLE
Auto-GPT requires numpy -- added to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ orjson
 Pillow
 coverage
 flake8
+numpy


### PR DESCRIPTION
### Background
Auto-GPT requires numpy, but numpy is not listed in `requirements.txt`, so following the install instructions can lead to an incomplete set of packages.

### Changes
Add numpy to `requirements.txt`

### Documentation
* no docs
* change is prompt-agnostic

### Test Plan
* run `pip install -r requirements.txt` on a system without numpy
* try to run Auto-GPT; it fails due to a failed numpy import
* add numpy to `requirements.txt`
* run `pip install -r requirements.txt` again
* Auto-GPT will now run at invocation of `scripts/main.py`

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 
