### PR TITLE
Removed redundant cfg object creation in base memory file

### DIFF
--- a/scripts/memory/base.py
+++ b/scripts/memory/base.py
@@ -2,7 +2,6 @@
 import abc
 from config import AbstractSingleton, Config
 import openai
-cfg = Config()
 
 cfg = Config()
 


### PR DESCRIPTION
Removed a redundant `cfg()` object creation in base.py of memory code section. Tested with a few prompts. 
