### PR TITLE
Remove deprecated (404) links, and add alt-text to one image: Update …

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![GitHub Repo stars](https://img.shields.io/github/stars/Torantulino/auto-gpt?style=social)
 ![Twitter Follow](https://img.shields.io/twitter/follow/siggravitas?style=social)
-[![](https://dcbadge.vercel.app/api/server/PQ7VX6TY4t?style=flat)](https://discord.gg/PQ7VX6TY4t)
-[![Unit Tests](https://github.com/Torantulino/Auto-GPT/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/Torantulino/Auto-GPT/actions/workflows/unit_tests.yml)
+[![Discord Follow](https://dcbadge.vercel.app/api/server/PQ7VX6TY4t?style=flat)](https://discord.gg/PQ7VX6TY4t)
 
 Auto-GPT is an experimental open-source application showcasing the capabilities of the GPT-4 language model. This program, driven by GPT-4, chains together LLM "thoughts", to autonomously achieve whatever goal you set. As one of the first examples of GPT-4 running fully autonomously, Auto-GPT pushes the boundaries of what is possible with AI.
 


### PR DESCRIPTION
…README.md

1. Removed the link to Unit-tests as that link is deprecated and on clicking on it, it says, that workflow no longer exists.

2. Added alt text to the Discord link, following the convention from Twitter link alt text

### Background
- When we click on the Unit-tests links, both the links no longer lead anywhere. So both links (one to the unit test workflow and another to unit test image) have been removed.
- Added alt text to Discord Link as it was missing.

### Changes
Delete deprecated link.
Added alt text to discord link.

### Documentation
It is part of readme, hence self-documented.

### Test Plan
Passes the lint-checkers for mark-down best practises.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes.
