### PR TITLE
remove output to set OpenAI API key in config.py

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -26,7 +26,7 @@ def check_openai_api_key():
     if not cfg.openai_api_key:
         print(
             Fore.RED +
-            "Please set your OpenAI API key in config.py or as an environment variable."
+            "Please set your OpenAI API key in .env or as an environment variable."
         )
         print("You can get your key from https://beta.openai.com/account/api-keys")
         exit(1)


### PR DESCRIPTION
### Background
config.py is not used anymore to hardcode the OpenAI API key, This is now done in the .env file.  

### Changes
Remove console output when OpenAI key is not set: "set in in config.py"

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes 