### PR TITLE
correctly set the path for Dockerfile and docker-compose in order to …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ COPY --chown=appuser:appuser requirements.txt .
 RUN pip install --no-cache-dir --user -r requirements.txt
 
 # Copy the application files
-COPY --chown=appuser:appuser scripts/ .
+COPY --chown=appuser:appuser scripts/ scripts/
+
 
 # Set the entrypoint
 ENTRYPOINT ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       - redis
     build: ./
     volumes:
-      - "./scripts:/app"
-      - ".env:/app/.env"
+      - ./.env:/home/appuser/scripts/.env
     profiles: ["exclude-from-up"]
 
   redis:


### PR DESCRIPTION
### Background
"docker-compose up" introduces following error:

```bash
auto-gpt_1  |   File "<frozen os>", line 225, in makedirs
auto-gpt_1  | PermissionError: [Errno 13] Permission denied: '../logs'
```
System: Ubuntu 20.04

### Changes
Correctly set script in a subfolder of the appuser, and modify the mounting volume in docker-compose correspondingly.

### Documentation
"docker-compose up" can be run successfully

### Test Plan
"docker-compose up" 

### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
