### PR TITLE
More robust log dir path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ last_run_ai_settings.yaml
 .idea/*
 auto-gpt.json
 log.txt
+logs
 
 # Coverage reports
 .coverage

--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -24,7 +24,8 @@ For console handler: simulates typing
 class Logger(metaclass=Singleton):
     def __init__(self):
         # create log directory if it doesn't exist
-        log_dir = os.path.join('..', 'logs')
+        this_files_dir_path = os.path.dirname(__file__)
+        log_dir = os.path.join(this_files_dir_path, '../logs')
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
 


### PR DESCRIPTION
### Background
When run from the root of the project `python scripts/main.py` the logger was logging in a directory outside of the project directory (in the parent)

### Changes
Make the log directory path (`../logs`) relative to the directory the logger file is in (ie. `./scripts/`). This puts the logs dir in the project directory.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes
